### PR TITLE
Eliminate duplicate waypoints in list

### DIFF
--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -282,6 +282,10 @@ FillList(WaypointList &list, const Waypoints &src,
 
   if (filter.distance > 0 || !filter.direction.IsNegative())
     list.SortByDistance(location);
+  else
+    list.SortByName();
+
+  list.MakeUnique();
 }
 
 static void

--- a/src/Waypoint/WaypointList.cpp
+++ b/src/Waypoint/WaypointList.cpp
@@ -62,3 +62,30 @@ WaypointList::SortByDistance(const GeoPoint &location) noexcept
 {
   std::sort(begin(), end(), WaypointDistanceCompare(location));
 }
+
+class WaypointNameCompare
+{
+public:
+  explicit WaypointNameCompare() noexcept {}
+
+
+  [[gnu::pure]]
+  bool operator()(const WaypointListItem &a,
+                  const WaypointListItem &b) const noexcept {
+    return a.waypoint->name < b.waypoint->name;
+  }
+};
+
+void
+WaypointList::SortByName() noexcept
+{
+  std::sort(begin(), end(), WaypointNameCompare());
+}
+
+void
+WaypointList::MakeUnique() noexcept
+{
+  auto new_end = std::unique(begin(), end(), [](WaypointListItem &a, WaypointListItem &b)
+                                        {return a.waypoint->name == b.waypoint->name;});
+  erase(new_end, end());
+}

--- a/src/Waypoint/WaypointList.hpp
+++ b/src/Waypoint/WaypointList.hpp
@@ -54,7 +54,9 @@ public:
 class WaypointList: public std::vector<WaypointListItem>
 {
 public:
+  void SortByName() noexcept;
   void SortByDistance(const GeoPoint &location) noexcept;
+  void MakeUnique() noexcept;
 };
 
 #endif


### PR DESCRIPTION
Retains filtering name and shortname but deletes duplicates
(e.g. when the shortname is the same as the name).  Also
eliminates duplicates when distance is the filter.  Bonus: this
should slightly speed up rendering of the waypoints on the map.
Closes #958
Closes #816


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
